### PR TITLE
fix: update a require path from bin/duck

### DIFF
--- a/bin/duck.js
+++ b/bin/duck.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../lib/src/cli').run(process.argv.slice(2));
+require('../lib/cli').run(process.argv.slice(2));


### PR DESCRIPTION
Currently, `duck` is being broken by the following error.

> Error: Cannot find module '../lib/src/cli'

This seems to be introduced by https://github.com/teppeis/duck/commit/89c18dabd6f4768b972e9f46486a62ba857cd0d0
