### PR TITLE
build(deps): update typescript to 3.5 RC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3965,9 +3965,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.0-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.0-rc.tgz",
+      "integrity": "sha512-8Os3bqTeHc6bf+bkPFL3O/pb09j8SbDa2LUBxTXWpZlcHUW9ziGuiEFiqMcArkbAjGLqEzshkl4zvxhb0gVPuQ==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "power-assert": "^1.6.1",
     "prettier": "^1.17.1",
     "rimraf": "^2.6.3",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.0-rc"
   },
   "homepage": "https://github.com/teppeis/duck",
   "repository": {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -69,11 +69,16 @@ export async function serve(config: DuckConfig, watch = true) {
       key: await promisify(readFile)(https.keyPath, 'utf8'),
       cert: await promisify(readFile)(https.certPath, 'utf8'),
     };
-    // TODO: fix typings
+    // Use `any` because the types of http, https and http2 modules in Node.js are not compatible.
+    // But it is not a big deal.
     if (http2) {
-      server = fastify({logger, https: httpsOptions, http2: true}) as any;
+      server = fastify({logger, https: httpsOptions, http2: true}) as fastify.FastifyInstance<
+        any,
+        any,
+        any
+      >;
     } else {
-      server = fastify({logger, https: httpsOptions}) as fastify.FastifyInstance;
+      server = fastify({logger, https: httpsOptions}) as fastify.FastifyInstance<any>;
     }
   } else {
     server = fastify({logger});


### PR DESCRIPTION
> [Announcing TypeScript 3.5 RC | TypeScript](https://devblogs.microsoft.com/typescript/announcing-typescript-3-5-rc/)

Build performance improvement of tsc (v3.4 → v3.5 RC)
- clean build: 3.3s → 3.0s
- incremental build: 1.7s → 1.4s

Also fixed the typing of `faast()` for new tsc that detects type errors more accurately.