### PR TITLE
feat: update deps.js on disk in serve command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 /test/fixtures
 # TODO: update eslint-config-teppeis and apply config for JS
 /test/bin-test
-/test/fixtures/*.js
+/test/fixtures/**/*-deps.js
 deps.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 /test/fixtures
 # TODO: update eslint-config-teppeis and apply config for JS
 /test/bin-test
+/test/fixtures/*.js
+deps.js

--- a/src/commands/buildDeps.ts
+++ b/src/commands/buildDeps.ts
@@ -10,7 +10,10 @@ export async function buildDeps(config: DuckConfig): Promise<void> {
   const paths = [config.inputsRoot];
   const googBaseDir = path.join(config.closureLibraryDir, 'closure', 'goog');
   logger.info(`Analyzing dependencies`);
-  const deps = await getDependencies({paths}, config.depsJsIgnoreDirs);
+  const deps = await getDependencies(
+    {paths},
+    config.depsJsIgnoreDirs.concat(config.closureLibraryDir)
+  );
   logger.info(`Generating deps.js`);
   const fileText = await generateDepFileTextFromDeps(deps, googBaseDir);
   if (config.depsJs) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -162,9 +162,10 @@ export async function createCompilerOptionsForChunks(
 ): Promise<{options: CompilerOptions; sortedChunkIds: string[]; rootChunkId: string}> {
   // TODO: separate EntryConfigChunks from EntryConfig
   const modules = assertNonNullable(entryConfig.modules);
+  const ignoreDirs = config.depsJsIgnoreDirs.concat(config.closureLibraryDir);
   const dependencies = flat(
     await Promise.all([
-      getDependencies(entryConfig, [config.closureLibraryDir]),
+      getDependencies(entryConfig, ignoreDirs),
       getClosureLibraryDependencies(config.closureLibraryDir),
     ])
   );

--- a/src/duckconfig.ts
+++ b/src/duckconfig.ts
@@ -6,7 +6,7 @@ export interface DuckConfig {
   closureLibraryDir: string;
   inputsRoot: string;
   depsJs?: string;
-  depsJsIgnoreDirs?: readonly string[];
+  depsJsIgnoreDirs: readonly string[];
   entryConfigDir: string;
   soyJarPath?: string;
   soyOptions?: SoyToJsOptions;
@@ -43,6 +43,7 @@ export function loadConfig(opts: any = {}): DuckConfig {
     toAbsPath(config, configDir, 'soyJarPath');
     toAbsPath(config, configDir, 'depsJs');
     toAbsPathArray(config, configDir, 'depsJsIgnoreDirs');
+    config.depsJsIgnoreDirs = config.depsJsIgnoreDirs || [];
     toAbsPathArray(config, configDir, 'soyFileRoots');
     if (config.soyOptions) {
       const {inputPrefix} = config.soyOptions;

--- a/test/fixtures/writeCachedDepsOnDisk/deps.js
+++ b/test/fixtures/writeCachedDepsOnDisk/deps.js
@@ -1,0 +1,3 @@
+goog.addDependency('../../closuremodule.js', ['closuremodule'], ['goog.array', 'goog.dom'], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../closureprovide.js', ['closureprovide1', 'closureprovide2'], ['goog.array', 'goog.dom'], {});
+goog.addDependency('../../script.js', [], ['goog.array', 'goog.dom'], {});


### PR DESCRIPTION
- improve watch log format
- watch ignores `config.depsJs` and `config.depsJsIgnoreDirs`