### PR TITLE
feat: widen supported version range of google-closure-compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ commands:
       - run:
           name: Test in the oldest Google Closure Tools
           command: |
-            CLOSURE_VER=20190325
-            npm i "google-closure-compiler@${CLOSURE_VER}" "google-closure-deps@${CLOSURE_VER}" "google-closure-library@${CLOSURE_VER}"
+            npm i --no-save google-closure-compiler@20180910 google-closure-deps@20190325
             npm run unit
       - run:
           name: Report coverage to codecov

--- a/package-lock.json
+++ b/package-lock.json
@@ -3533,12 +3533,6 @@
         }
       }
     },
-    "google-closure-library": {
-      "version": "20190618.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20190618.0.0.tgz",
-      "integrity": "sha512-V0RbatvAmCfdOTeTXXbXklGU1hgPus8YkpjyaMBmoCcajgtk9vL+SsRhD1Ntk6QNkbzD9WGKLdyovMw7NJ8VnA==",
-      "dev": true
-    },
     "google-p12-pem": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "eslint-config-teppeis": "^10.0.0-alpha.7",
     "espower-typescript": "^9.0.2",
     "google-closure-compiler": "^20190618.0.0",
-    "google-closure-library": "^20190618.0.0",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "execa": "^1.0.0",
     "faastjs": "^3.0.2",
     "fastify": "^2.5.0",
-    "google-closure-compiler": ">=20190325.0.0",
     "google-closure-deps": ">=20190325.0.0",
     "listr": "^0.14.3",
     "merge-options": "^1.0.1",
@@ -55,6 +54,9 @@
     "xmlbuilder": "^13.0.2",
     "yargs": "^13.2.4",
     "zet": "^1.0.5"
+  },
+  "peerDependencies": {
+    "google-closure-compiler": ">=20180716.0.1"
   },
   "devDependencies": {
     "@types/chokidar": "^2.1.3",
@@ -74,7 +76,8 @@
     "eslint": "^6.0.0",
     "eslint-config-teppeis": "^10.0.0-alpha.7",
     "espower-typescript": "^9.0.2",
-    "google-closure-library": ">=20190325.0.0",
+    "google-closure-compiler": "^20190618.0.0",
+    "google-closure-library": "^20190618.0.0",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "extends": ["@teppeis:anytime"],
   "packageRules": [
     {
-      "groupName": "Google Closure Tools",
-      "packagePatterns": ["^google-closure-"],
+      "packageName": ["google-closure-deps"],
       "rangeStrategy": "update-lockfile"
     }
   ]

--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -131,12 +131,16 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
       }
       const { message: stderr } = result.reason as Error;
       const [command, , ...messages] = stderr.split("\n");
-      const items: CompileErrorItem[] = JSON.parse(messages.join("\n"));
-      return {
-        entryConfigPath: result.entryConfigPath,
-        command,
-        items,
-      };
+      try {
+        const items: CompileErrorItem[] = JSON.parse(messages.join("\n"));
+        return {
+          entryConfigPath: result.entryConfigPath,
+          command,
+          items,
+        };
+      } catch {
+        throw new Error(`Unexpected non-JSON error: ${stderr}`);
+      }
     });
   if (reasons.length > 0) {
     throw new BuildJsCompilationError(reasons, results.length);

--- a/src/compiler-core.ts
+++ b/src/compiler-core.ts
@@ -7,8 +7,11 @@ import { logger } from "./logger";
 
 export interface CompilerOptions {
   [idx: string]: any;
-  // 'LOOSE' and 'STRICT' are deprecated. Use 'PRUNE_LEGACY' and 'PRUNE' respectedly.
-  dependency_mode?: "NONE" | "SORT_ONLY" | "PRUNE_LEGACY" | "PRUNE";
+  /**
+   * `LOOSE` and `STRICT` are deprecated. Use `PRUNE_LEGACY` and `PRUNE` respectedly.
+   * See https://github.com/google/closure-compiler/commit/bab8ee8274abc162f72aa64ebe573c83ed38bb20
+   */
+  dependency_mode?: "NONE" | "SORT_ONLY" | "PRUNE_LEGACY" | "PRUNE" | "LOOSE" | "STRICT";
   entry_point?: readonly string[];
   compilation_level?: CompilationLevel;
   js?: readonly string[];

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -61,7 +61,9 @@ function createBaseOptions(entryConfig: EntryConfig, outputToFile: boolean): Com
     }
   } else {
     // for pages
-    opts.dependency_mode = "PRUNE";
+    // `STRICT` is deprecated in google-closure-compiler@20181205.
+    // TODO: use `PRUNE` instead and drop support earlier than v20181205.
+    opts.dependency_mode = "STRICT";
     const js = entryConfig.paths.slice();
     if (entryConfig.externs) {
       js.push(...entryConfig.externs.map(extern => `!${extern}`));

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,7 +7,10 @@ export type CompileErrorItem = CompileErrorCase | CompileErrorInfo;
 export interface CompileErrorCase {
   level: "warning" | "error";
   description: string;
-  key: string;
+  /**
+   * Added in google-closure-compiler@20180910
+   */
+  key?: string;
   source: string;
   line: number;
   column: number;

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -17,7 +17,7 @@ describe("compiler", () => {
         false
       );
       const expected: CompilerOptions = {
-        dependency_mode: "PRUNE",
+        dependency_mode: "STRICT",
         json_streams: "OUT",
         compilation_level: "WHITESPACE",
         js: ["/path/to/path1"],
@@ -57,7 +57,7 @@ describe("compiler", () => {
         true
       );
       const expected: CompilerOptions = {
-        dependency_mode: "PRUNE",
+        dependency_mode: "STRICT",
         compilation_level: "SIMPLE",
         js: ["/path/to/path1", "!/extern1.js"],
         entry_point: ["/input1.js"],


### PR DESCRIPTION
BREAKING CHANGE: google-closure-compiler was moved from deps to peerDeps