### PR TITLE
fix: chunk entries don't work on AWS batch mode

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -226,6 +226,10 @@ export async function createCompilerOptionsForChunks(
     assertNonNullable(compilerOptions.compilation_level),
     createModuleUris
   );
+  if (duckConfig.batch === "aws") {
+    convertCompilerOptionsToRelative(compilerOptions);
+  }
+
   const options: ExtendedCompilerOptions = {
     compilerOptions,
   };


### PR DESCRIPTION
Currently, the following error occurs when I run `duck build` with a chunk entry config on AWS batch mode

```
Cannot read file /Users/koba04/project/path/to/js
```

The reason why the error happens is that JS files in compiler options are absolute path in my local machine.

This PR makes the path a relative path.