### PR TITLE
fix: build doesn't work if inputsRoot dir includes dead symlink

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@types/chokidar": "^2.1.3",
     "@types/common-tags": "^1.8.0",
+    "@types/glob": "^7.1.1",
     "@types/listr": "^0.14.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.17",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "execa": "^2.0.4",
     "faastjs": "^3.0.7",
     "fastify": "^2.7.1",
+    "glob": "^7.1.4",
     "google-closure-deps": ">=20190325.0.0",
     "listr": "^0.14.3",
     "merge-options": "^1.0.1",

--- a/src/gendeps.ts
+++ b/src/gendeps.ts
@@ -103,7 +103,6 @@ export async function getDependencies(
       const files = await globPromise(path.join(p, "**/*.js"), { ignore: ignoreDirPatterns });
       return Promise.all(
         files
-          .filter(file => /\.js$/.test(file))
           // TODO: load deps.js path from config
           .filter(file => !/\bdeps\.js$/.test(file))
           .filter(file => {


### PR DESCRIPTION
`duck serve` doesn't work with dead symlink. That's why [recursive-readdir](https://github.com/jergason/recursive-readdir) occurs an error when 'inputsRoot' directory includes some dead symlinks.
There is a [PR](https://github.com/jergason/recursive-readdir/pull/60/files) to fix it. 
However, recursive-readdir is not active very much. The PR was created over a year ago.
So, I recommend to use [glob](https://github.com/isaacs/node-glob) instead of recursive-readdir.