### PR TITLE
fix: follow symlinks in deps.js

### DIFF
--- a/src/gendeps.ts
+++ b/src/gendeps.ts
@@ -100,7 +100,7 @@ export async function getDependencies(
       if (entryConfig["test-excludes"]) {
         testExcludes = entryConfig["test-excludes"];
       }
-      const files = await globPromise(path.join(p, "**/*.js"), { ignore: ignoreDirPatterns });
+      const files = await globPromise(path.join(p, "**/*.js"), { ignore: ignoreDirPatterns, follow: true });
       return Promise.all(
         files
           // TODO: load deps.js path from config


### PR DESCRIPTION
#225 breaks our tests because `glob` doesn't follow symlinks by default, which is not the behavior with `recursive-readdir`.
This PR adds an option to be able to follow symlinks.