### PR TITLE
docs: fix a link to example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Options:
   -h, --help              Show help                                                      [boolean]
 ```
 
-Also see [`examples/chunks`](examples/chunks).
+Also see [`examples`](examples).
 
 ## Tips
 


### PR DESCRIPTION
fixes #277