### PR TITLE
feat: add strict option for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Options:
   --config                A path to duck.config.js, the extension can be ommited          [string]
   --concurrency, -c       Concurrency limit of Closure Compiler                           [number]
   --batch                 Build in batch mode (on AWS or local for debug)[choices: "aws", "local"]
+  --strict                Treat an warning as an error                  [boolean] [default: false]
   --reporters             Test reporters ("text", "xunit" or "json")   [array] [default: ["text"]]
   --reporterOptions       Test reporter options
   --printConfig, -p       Print effective configs for compilers         [boolean] [default: false]
@@ -129,7 +130,7 @@ $ duck build --batch aws
 - Use `--batch local` for [local debugging](https://faastjs.org/docs/local)
 - Use `DEBUG=faast:info` or [other log level](https://faastjs.org/docs/workflow#debug-environment-variable) to get more debug information
 - Get `logUrl` from debug info and view it in CloudWatch logs
-- Use `FAAST_PACKAGE_DIR=foo/bar` to investigate a package sent to Lambda 
+- Use `FAAST_PACKAGE_DIR=foo/bar` to investigate a package sent to Lambda
 
 Also see [faast.js document](https://faastjs.org/docs/api/faastjs.awsoptions) for more information.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,6 +131,11 @@ const buildJsOptions = {
     desc: "Build in batch mode (on AWS or local for debug)",
     choices: ["aws", "local"],
   },
+  strict: {
+    desc: "Treat warning as error",
+    type: "boolean",
+    default: false,
+  },
   reporters: {
     desc: 'Test reporters ("text", "xunit" or "json")',
     type: "array",

--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -126,8 +126,18 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
       if (!result.isRejected) {
         throw new Error("Unexpected state");
       }
+      const compilerError = result.reason as CompilerError;
       const { message: stderr } = result.reason as CompilerError;
-      const [command, , ...messages] = stderr.split("\n");
+      let command = "";
+      let messages: string[] = [];
+      if (compilerError.level === "error") {
+        [command, , ...messages] = stderr.split("\n");
+        // TODO: How can I get a command with a warning error
+      } else if (compilerError.level === "warning") {
+        messages = stderr.split("\n");
+      } else {
+        throw new Error(`Found an unknown compiler error level: ${compilerError.level}`);
+      }
       try {
         const items: CompileErrorItem[] = JSON.parse(messages.join("\n"));
         return {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -192,6 +192,9 @@ export function createCompilerOptionsForPage(
   if (duckConfig.batch) {
     extendedOpts.batch = duckConfig.batch;
   }
+  if (duckConfig.strict) {
+    extendedOpts.strict = duckConfig.strict;
+  }
   return extendedOpts;
 }
 
@@ -238,6 +241,9 @@ export async function createCompilerOptionsForChunks(
   }
   if (duckConfig.batch) {
     options.batch = duckConfig.batch;
+  }
+  if (duckConfig.strict) {
+    options.strict = duckConfig.strict;
   }
   return { options, sortedChunkIds, rootChunkId: sortedChunkIds[0] };
 }

--- a/src/duckconfig.ts
+++ b/src/duckconfig.ts
@@ -19,6 +19,7 @@ export interface DuckConfig {
   soyFileRoots?: readonly string[];
   concurrency?: number;
   batch?: "aws" | "local";
+  strict?: boolean;
   batchOptions?: import("faastjs").AwsOptions | import("faastjs").LocalOptions;
   reporters?: ("json" | "text" | "xunit")[];
   reporterOptions?: {


### PR DESCRIPTION
This is a PR to fix #285 
`--strict` option treats any warnings as an error.
This is useful when you don't want to allow any warnings on you compiling.