### PR TITLE
fix: format output without warnings

### DIFF
--- a/src/commands/buildJs.ts
+++ b/src/commands/buildJs.ts
@@ -122,7 +122,9 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
     }))
     .map(result => {
       if (result.isFulfilled) {
-        if (result.value) {
+        // if items doesn't include any warnings, we ignore the line of summary
+        // 0 error(s), 0 warning(s), xx% typed
+        if (result.value && result.value.length > 1) {
           return {
             entryConfigPath: result.entryConfigPath,
             command: "",
@@ -150,7 +152,8 @@ async function waitAllAndThrowIfAnyCompilationsFailed(
           throw new Error(`Unexpected non-JSON error: ${stderr}`);
         }
       }
-    });
+    })
+    .filter(result => result.items.length > 0);
   if (results.filter(result => result.isRejected).length > 0) {
     throw new BuildJsCompilationError(reasons, results.length);
   }

--- a/src/reporters/text-reporter.ts
+++ b/src/reporters/text-reporter.ts
@@ -16,6 +16,9 @@ export class TextReporter extends BaseReporter {
   }
 
   format({ entryConfigPath, command, items }: ErrorReason): string {
+    if (items.length === 0) {
+      return "";
+    }
     return `# ${entryConfigPath}:
 
 ${command}


### PR DESCRIPTION
This fixes 1. of https://github.com/teppeis/duck/pull/296#issuecomment-555804880

Before

```
➜  npx duck build
  ✔ Compile Soy templates
  ✔ Generate deps.js
  ✔ Compile JS files
# <file path>



0 error(s), 0 warning(s), 98.4% typed
➜
```

After
```
➜  npx duck build
  ✔ Compile Soy templates
  ✔ Generate deps.js
  ✔ Compile JS files
➜
```