### PR TITLE
deps: update closure-compiler version in peerDeps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
       - run:
           name: Test in the oldest Google Closure Tools
           command: |
-            npm i --no-save google-closure-compiler@20180101 google-closure-deps@20190325
+            npm i --no-save google-closure-compiler@20180910 google-closure-deps@20190325
             npm run unit
       - run:
           name: Report coverage to codecov

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "zet": "^1.1.0"
   },
   "peerDependencies": {
-    "google-closure-compiler": ">=20180101.0.0"
+    "google-closure-compiler": ">=20180910.1.0"
   },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,10 +7,7 @@ export type CompileErrorItem = CompileErrorCase | CompileErrorInfo;
 export interface CompileErrorCase {
   level: "warning" | "error";
   description: string;
-  /**
-   * Added in google-closure-compiler@20180910
-   */
-  key?: string;
+  key: string;
   source: string;
   line: number;
   column: number;

--- a/src/reporters/text-reporter.ts
+++ b/src/reporters/text-reporter.ts
@@ -31,7 +31,7 @@ ${items
 
   private formatErrorCase(item: CompileErrorCase): string {
     const { source, line, column, level, key, description, context } = item;
-    const errorCode = key ? `[${key}] ` : "";
+    const errorCode = `[${key}] `;
     const code = context ? `\n${context}` : "";
     return `${source}:${line}:${column} ${level.toUpperCase()} - ${errorCode}${description}${code}`;
   }

--- a/src/reporters/xunit-reporter.ts
+++ b/src/reporters/xunit-reporter.ts
@@ -28,7 +28,7 @@ export class XUnitReporter extends BaseReporter {
         const testcase = testsuite
           .element("testcase")
           .attribute("classname", error.source)
-          .attribute("name", error.key || error.description);
+          .attribute("name", error.key);
         const message = `${error.description} (line ${error.line}, col ${error.column})`;
         const failure = testcase.element("failure").attribute("message", message);
         if (error.context) {

--- a/test/text-reporter.ts
+++ b/test/text-reporter.ts
@@ -84,31 +84,5 @@ ${command}
 `
       );
     });
-
-    it("error without key", async () => {
-      const actual = reporter.format({
-        entryConfigPath,
-        command,
-        items: [
-          {
-            level: "error",
-            description:
-              "Class goog.structs.Map has been deprecated: This type is misleading: use ES6 Map instead.",
-            source: "/path/to/node_modules/google-closure-library/closure/goog/debug/tracer.js",
-            line: 57,
-            column: 32,
-          },
-        ],
-      });
-      assert.equal(
-        actual,
-        `# /path/to/entryConfig.json:
-
-${command}
-
-/path/to/node_modules/google-closure-library/closure/goog/debug/tracer.js:57:32 ERROR - Class goog.structs.Map has been deprecated: This type is misleading: use ES6 Map instead.
-`
-      );
-    });
   });
 });

--- a/test/xunit-reporter.ts
+++ b/test/xunit-reporter.ts
@@ -143,33 +143,5 @@ describe("XUnitReporter", () => {
       </testsuites>`.replace(/%%newline%%/g, "\n")
       );
     });
-
-    it("error without key", async () => {
-      const actual = reporter.format({
-        entryConfigPath,
-        command,
-        items: [
-          {
-            level: "error",
-            description:
-              "Class goog.structs.Map has been deprecated: This type is misleading: use ES6 Map instead.",
-            source: "/path/to/node_modules/google-closure-library/closure/goog/debug/tracer.js",
-            line: 57,
-            column: 32,
-          },
-        ],
-      });
-      assert.equal(
-        actual,
-        oneLineTrim`<?xml version="1.0"?>
-      <testsuites>
-        <testsuite name="${entryConfigPath}">
-          <testcase classname="/path/to/node_modules/google-closure-library/closure/goog/debug/tracer.js" name="Class goog.structs.Map has been deprecated: This type is misleading: use ES6 Map instead.">
-            <failure message="Class goog.structs.Map has been deprecated: This type is misleading: use ES6 Map instead. (line 57, col 32)"/>
-          </testcase>
-        </testsuite>
-      </testsuites>`.replace(/%%newline%%/g, "\n")
-      );
-    });
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: no longer support google-closure-compiler@<20180910.1.0

Fixes https://github.com/teppeis/duck/issues/282#issuecomment-558919454

Does this `key` become not optional?
https://github.com/teppeis/duck/blob/master/src/report.ts#L13